### PR TITLE
Fix two errors on php7

### DIFF
--- a/include/global.func.php
+++ b/include/global.func.php
@@ -376,7 +376,7 @@ function getchat($last,$team='',$limit=0) {
 	global $db,$tablepre,$chatlimit,$chatinfo,$plsinfo;
 	$limit = $limit ? $limit : $chatlimit;
 	$result = $db->query("SELECT * FROM {$tablepre}chat WHERE cid>'$last' AND (type!='1' OR (type='1' AND recv='$team')) ORDER BY cid desc LIMIT $limit");
-	$chatdata = Array('lastcid' => $last, 'msg' => '');
+	$chatdata = Array('lastcid' => $last, 'msg' => array());
 	if(!$db->num_rows($result)){$chatdata = array('lastcid' => $last, 'msg' => '');return $chatdata;}
 	
 	while($chat = $db->fetch_array($result)) {


### PR DESCRIPTION
#### 试图解决以下问题：
在`PHP7.4.30`下，游戏页面的消息显示为空。
`parse_template()`中所使用的`\e`修饰的正则表达式自`PHP5.5`起已不再被支持，将产生`E_WARNING`。将对应的`preg_replace()`替换为`preg_replace_callback()`

#### 测试：
在`PHP7.4.30`与`PHP5.4.16`下，至二禁无异样，页首各链接页面显示无异样。
与5.4.16下未修改的`parse_template`函数生成的各`tpl.php`文件进行diff，除`1_lastnews.tpl.php`,`1_newsinfo.tpl.php`的具体内容以外无区别。

~~PS:如果风格不当或者有什么错误，望指正~~
