### PR TITLE
Update & Fix

### DIFF
--- a/command.php
+++ b/command.php
@@ -44,6 +44,7 @@ extract($pdata,EXTR_REFS);
 $log = $cmd = $main = '';
 $gamedata = array();
 init_playerdata();
+$clbpara = get_clbpara($clbpara);
 
 //读取玩家互动信息
 $result = $db->query("SELECT lid,time,log FROM {$tablepre}log WHERE toid = '$pid' AND prcsd = 0 ORDER BY time,lid");

--- a/game.php
+++ b/game.php
@@ -38,6 +38,7 @@ if($gamestate == 0) {
 extract($pdata);
 init_playerdata();
 init_profile();
+$clbpara = get_clbpara($clbpara);
 
 $log = '';
 //读取聊天信息

--- a/gamedata/cache/audio_1.php
+++ b/gamedata/cache/audio_1.php
@@ -6,7 +6,14 @@ if(!defined('IN_GAME')) exit('Access Denied');
 # 未配置的默认播放音量（单位：百分比）
 $default_volume = 20;
 
-# 会播放BGM的地图（优先级高）
+# 会播放BGM的事件（优先级最高——会覆盖默认曲集） 
+# 具体触发时用不用这个数组都无所谓，可以直接调用： $clbpara['event_bgmbook'] = Array('指定事件曲集名');
+$event_bgm = Array
+(
+	'test' => Array('event'),
+);
+
+# 会播放BGM的地图（优先级高——会覆盖默认曲集）
 $pls_bgm = Array
 (
 	# 在英灵殿会播放对应曲集

--- a/gamedata/cache/style_20190718.css
+++ b/gamedata/cache/style_20190718.css
@@ -28,10 +28,10 @@ input {cursor: crosshair;}
 .mapspanred{color:#f00;position:relative;font-size: 9pt;line-height:16px}
 .mapspanlime{color:#0f0;position:relative;font-size: 9pt;line-height:16px}
 .mapspanyellow{color:#ff0;position:relative;font-size: 9pt;line-height:16px}
-.minimapspanclan{color:#00ffff;position:relative;font: 7pt "微软雅黑";line-height:14px}
-.minimapspanred{color:#f00;position:relative;font: 7pt "微软雅黑";line-height:14px}
-.minimapspanlime{color:#0f0;position:relative;font: 7pt "微软雅黑";line-height:14px}
-.minimapspanyellow{color:#ff0;position:relative;font: 7pt "微软雅黑";line-height:14px}
+.minimapspanclan{color:#00ffff;position:relative;font:bold 7pt "微软雅黑";line-height:14px}
+.minimapspanred{color:#f00;position:relative;font:bold 7pt "微软雅黑";line-height:14px}
+.minimapspanlime{color:#0f0;position:relative;font:bold 7pt "微软雅黑";line-height:14px}
+.minimapspanyellow{color:#ff0;position:relative;font:bold 7pt "微软雅黑";line-height:14px}
 
 .b1 span{position:relative;}
 .b2 span{position:relative;}

--- a/include/admin/npcmng.php
+++ b/include/admin/npcmng.php
@@ -44,7 +44,7 @@ if($command == 'kill' || $command == 'live' || $command == 'del') {
 						$operlist[${'npc_'.$i}] = $npcdata[$i]['name'].'(PID:'.$npcdata[$i]['pid'].')';
 						$npcdata[$i]['hp'] = $npcdata[$i]['mhp'];
 						$npcdata[$i]['state'] = 0;
-						$deathnum --;$alivenum++;
+						$deathnum --; //$alivenum++;
 						adminlog('livenpc',$npcdata[$i]['name']);
 					}else{
 						$gfaillist[] = $npcdata[$i]['name'].'(PID:'.$npcdata[$i]['pid'].')';
@@ -55,7 +55,7 @@ if($command == 'kill' || $command == 'live' || $command == 'del') {
 						$operlist[${'npc_'.$i}] = $npcdata[$i]['name'].'(PID:'.$npcdata[$i]['pid'].')';	
 						$npcdata[$i]['hp'] = 0;
 						$npcdata[$i]['state'] = 16;
-						$deathnum --;$alivenum++;
+						$deathnum ++;//$alivenum++;
 						adminlog('delnpc',$npcdata[$i]['name']);
 					}else{
 						$operlist2[${'npc_'.$i}] = $npcdata[$i]['name'].'(PID:'.$npcdata[$i]['pid'].')';

--- a/include/admin/pcmng.php
+++ b/include/admin/pcmng.php
@@ -57,7 +57,7 @@ if($command == 'kill' || $command == 'live' || $command == 'del') {
 						$operlist[${'pc_'.$i}] = $pcdata[$i]['name'];	
 						$pcdata[$i]['hp'] = 0;
 						$pcdata[$i]['state'] = 16;
-						$deathnum --;$alivenum++;
+						$deathnum ++;$alivenum--;
 						adminlog('delpc',$pcdata[$i]['name']);
 						addnews($now,'death16',$pcdata[$i]['name']);
 					}else{

--- a/include/game.func.php
+++ b/include/game.func.php
@@ -541,7 +541,7 @@ function init_bgm($force_update=0)
 		# 生成播放器与播放队列 太野蛮了……嘻嘻……
 		if(!empty($bgmlink) && !empty($bgmtype))
 		{
-			$bgmplayer = <<<EOT
+$bgmplayer = <<<EOT
 			<audio id="gamebgm" autoplay controls onplay="$('gamebgm').volume=$volume_r;" onplaying="$('gamebgm').volume=$volume_r;">
 				<source id="gbgm" src="$bgmlink" type="$bgmtype">
 			</audio>
@@ -555,11 +555,9 @@ function init_bgm($force_update=0)
 EOT;
 			foreach($bgmarr as $bgmid2 => $bgms)
 			{
-				$bgmplayer .= <<<EOT
-				<div id="bnm{$bgmid2}">{$bgms['name']}</div>
-				<div id="bgm{$bgmid2}">{$bgms['url']}</div>
-				<div id="bt{$bgmid2}">{$bgms['type']}</div>
-EOT;	
+$bgmplayer .= "<div id=\"bnm{$bgmid2}\">{$bgms['name']}</div>
+				<div id=\"bgm{$bgmid2}\">{$bgms['url']}</div>
+				<div id=\"bt{$bgmid2}\">{$bgms['type']}</div>";
 			}
 		}
 		return $bgmplayer;
@@ -572,8 +570,8 @@ EOT;
 
 function init_mapdata(){
 	global $pls,$plsinfo,$xyinfo,$hack,$arealist,$areanum,$areaadd;
-	global $mapcontent;
 
+	$mpp = Array();
 	$mapvcoordinate = Array('A','B','C','D','E','F','G','H','I','J');
 	for($i=0;$i<count($plsinfo);$i++)
 	{
@@ -587,9 +585,8 @@ function init_mapdata(){
 		$position=explode('-',$xyinfo[$i]);
 		$mpp[$position[0]][$position[1]]=$i;
 	}
-	$mapcontent = <<<EOT
-	<TABLE border="1" cellspacing="0" cellpadding="0" background="map/neomap.jpg" style="padding-left: 5px; float:left;background-size:478px 418px;position:relative;background-repeat:no-repeat;background-position:right bottom;">
-EOT;	
+
+	$mapcontent = '<TABLE border="1" cellspacing="0" cellpadding="0" background="map/neomap.jpg" style="padding-left: 5px; float:left;background-size:478px 418px;position:relative;background-repeat:no-repeat;background-position:right bottom;">';	
 	$mapcontent .= '<TR align="center"><TD colspan="11" height="24" class=b1 align=center>战场地图</TD></TR>';
 	$mapcontent .= '<TR align="center">
 			<TD width="42" height="36" class=map align=center><div class=nttx>坐标</div></TD>';
@@ -603,9 +600,7 @@ EOT;
 		for($j=1;$j<=10;$j++){
 			if(isset($mpp[$mapvcoordinate[$i]][$j]))
 			{
-$mapcontent .= <<<EOT
-					<td width="42" height="36" class="map2" align=middle><a onclick="closeDialog($('terminal'));$('mode').value='command';$('command').value='move';$('moveto').value='{$mpp[$mapvcoordinate[$i]][$j]}';postCmd('gamecmd','command.php');this.disabled=true;"><span class="{$plscolor[$mpp[$mapvcoordinate[$i]][$j]]}">{$plsinfo[$mpp[$mapvcoordinate[$i]][$j]]}</span></a></td>
-EOT;
+				$mapcontent .="<td width=\"42\" height=\"36\" class=\"map2\" align=\"middle\"><a onclick=\"closeDialog($('terminal'));$('mode').value='command';$('command').value='move';$('moveto').value='{$mpp[$mapvcoordinate[$i]][$j]}';postCmd('gamecmd','command.php');this.disabled=true;\"><span class=\"{$plscolor[$mpp[$mapvcoordinate[$i]][$j]]}\">{$plsinfo[$mpp[$mapvcoordinate[$i]][$j]]}</span></a></td>";
 			}else{
 				$mapcontent .= '<td width="42" height="36" class="map2" align=middle><IMG src="map/blank.gif" width="42" height="36" border=0></td>';
 			}

--- a/include/game/item.func.php
+++ b/include/game/item.func.php
@@ -1866,6 +1866,19 @@ function itemuse($itmn) {
 			//销毁物品
 			$itm = $itmk = $itmsk = '';
 			$itme = $itms = 0;
+		} elseif ($itm == '事件BGM替换器'){
+			// 这是一个触发事件BGM的案例，只要输入$clbpara['event_bgmbook'] = Array('事件曲集名'); 即可将当前曲集替换为特殊事件BGM
+			// 特殊事件曲集'event_bgmbook'的优先级高于地图曲集'pls_bgmbook'，前者存在时后者不会生效
+			global $clbpara;
+			include_once config('audio',$gamecfg);
+			$log.="【DEBUG】你目前的播放列表被替换为了{$event_bgm['test'][0]}！<br>特殊的事件曲集不会被其他曲集覆盖，除非你使用下面的道具。<br>";
+			$clbpara['event_bgmbook'] = $event_bgm['test'];
+		} elseif ($itm == '事件BGM还原器'){
+			// 这是一个取消事件BGM的案例，只要unset($clbpara['event_bgmbook']);就可以将当前曲集替换为地图曲集或默认曲集；
+			// 如果你想播放另一个事件曲集，也可以$clbpara['event_bgmbook'] = Array('另一个事件曲集名');
+			global $clbpara;
+			$log.="【DEBUG】你目前的播放列表还原为了默认播放列表！<br>";
+			unset($clbpara['event_bgmbook']);
 		} elseif ($itm == '测试用元素口袋'){
 			global $elements_info;
 			$log.="【DEBUG】你不知道从哪里摸出来一大堆元素！<br>";
@@ -1922,15 +1935,6 @@ function itemuse($itmn) {
 			$itm = $itmk = $itmsk = '';
 			$itme = $itms = 0;
 			//-----------------------//
-		} elseif ($itm == '电子蛐蛐测试装置') {
-			//这是一个测试用道具 设置好$nid（先手者pid）和$eid（挨打者pid）后可以看这两个人打架 把其中一个设置成自己的pid就可以亲自下场 //自己下场现在有BUG
-			//$nid：先手攻击者的pid；$eid：挨打者的pid
-			//如果$nid打死了$eid的话，尸体会由你来摸，这不是BUG，是一个暂时缺少条件判断的特性。
-			global $pid;
-			$nid = $pid; $eid = 2;
-			include_once GAME_ROOT.'./include/game/revcombat.func.php';
-			rev_combat_prepare($nid,$eid);
-			return;
 		} elseif ($itm == '提示纸条A') {
 			$log .= '你读着纸条上的内容：<br>“执行官其实都是幻影，那个红暮的身上应该有召唤幻影的玩意。”<br>“用那个东西然后打倒幻影的话能用游戏解除钥匙出去吧。”<br>';
 		} elseif ($itm == '提示纸条B') {

--- a/include/game/revcombat.func.php
+++ b/include/game/revcombat.func.php
@@ -600,9 +600,12 @@
 					get_killer_rp($pa,$pd,$active);
 					# 执行死亡事件（灵魂绑定等）
 					check_death_events($pa,$pd,$active);
-					# 检查成就
-					include_once GAME_ROOT.'./include/game/achievement.func.php';
-					check_battle_achievement($pa['name'],$pd['type'],$pd['name'],$pa['wep_name']);	
+					# 检查成就 大补丁：击杀者是玩家时才会检查成就
+					if(!$pa['type'])
+					{
+						include_once GAME_ROOT.'./include/game/achievement.func.php';
+						check_battle_achievement($pa['name'],$pd['type'],$pd['name'],$pa['wep_name']);	
+					}
 					# 保存游戏进行状态
 					include_once GAME_ROOT.'./include/system.func.php';
 					save_gameinfo();

--- a/include/game/search.func.php
+++ b/include/game/search.func.php
@@ -382,6 +382,7 @@ function search(){
 
 function discover($schmode = 0) {
 	global $art,$pls,$now,$log,$mode,$command,$cmd,$event_obbs,$weather,$pls,$club,$pose,$tactic,$inf,$item_obbs,$enemy_obbs,$trap_min_obbs,$trap_max_obbs,$bid,$db,$tablepre,$gamestate,$corpseprotect,$action,$skills,$rp,$aidata;
+	global $clbpara;
 	$event_dice = rand(0,99);
 	if(($event_dice < $event_obbs)||(($art!="Untainted Glory")&&($pls==34)&&($gamestate != 50))){
 		//echo "进入事件判定<br>";
@@ -393,6 +394,18 @@ function discover($schmode = 0) {
 			$mode = 'command';
 			return;
 		}
+	}
+
+	# 判定移动、探索、事件后的BGM变化
+	include_once config('audio',$gamecfg);
+	if(array_key_exists($pls,$pls_bgm))
+	{
+		$clbpara['pls_bgmbook'] = $pls_bgm[$pls];
+	}
+	else
+	{
+		if(isset($clbpara['pls_bgmbook'])) 
+			unset($clbpara['pls_bgmbook']);
 	}
 	
 	include_once GAME_ROOT. './include/game/aievent.func.php';//AI事件
@@ -520,7 +533,7 @@ function discover($schmode = 0) {
 	{
 		//echo "进入遇敌判定<br>";
 		global $pid,$corpse_obbs,$teamID,$fog,$bid,$gamestate;
-		global $clbpara,$clbstatusa,$clbstatusb,$clbstatusc,$clbstatusd,$clbstatuse;
+		global $clbstatusa,$clbstatusb,$clbstatusc,$clbstatusd,$clbstatuse;
 
 		$result = $db->query("SELECT * FROM {$tablepre}players WHERE pls='$pls' AND pid!='$pid'");
 		if(!$db->num_rows($result)){

--- a/include/news.func.php
+++ b/include/news.func.php
@@ -168,7 +168,8 @@ function  nparse_news($start = 0, $range = 0  ){//$type = '') {
 			} else {
 				$newsinfo .= "<li>{$hour}时{$min}分{$sec}秒，<span class=\"yellow\">$a</span>因<span class=\"red\">不明原因</span>死亡";
 			}
-			$dname = $typeinfo[$b].' '.$a;
+			if($b) $dname = $typeinfo[$b].' '.$a;
+			else $dname = $typeinfo[0].' '.$a;
 //			if($b == 0) {
 //				//$dname = $a;
 //				$lwresult = $db->query("SELECT lastword FROM {$tablepre}users WHERE username = '$a'");


### PR DESCRIPTION
变化：
新增事件曲集触发功能，优先级高于地图曲集，可以使用 事件BGM替换器 进行测试，使用 事件BGM还原器 可以去除事件曲集；
现在事件、地图bgm播放完后不会再播放默认bgm，而是会在本列表内循环；

修复：
bgmplayer不兼容PHP5.6的问题；
NPC击杀玩家时也会尝试判断完成成就的问题（成就可能会算到和NPC同名的账户身上…^ ^;）；
修复了祖传的管理后台杀人加幸存数的问题；