### PR TITLE
fix

### DIFF
--- a/gamedata/cache/style_20190718.css
+++ b/gamedata/cache/style_20190718.css
@@ -365,16 +365,18 @@ background-image: url("../../img/footer_line.gif");
 /* tooltip样式 摆脱title了！ */
 span[tooltip] {
     position: relative;
+	overflow: auto;
 }
 span[tooltip]:hover:before {
     content: attr(tooltip);
-	overflow-x:hidden;overflow-y:auto; padding: 3px; 
+	overflow: auto; padding: 5px;
 	font: bold 10pt "微软雅黑" serif; color: white; 
 	white-space:pre-line;
 	text-shadow:3px 3px 3px #3b3535; text-align: center; text-fill-color: white; -webkit-text-fill-color: white;
 	background-size: 0; background-clip: border-box; background-color: rgba(198, 114, 199, 0.8);
-	top: 20px; left: -5px; border-radius: 2px;
-    width: 160px; max-width: 160px; z-index: 3; position: absolute;  z-index: 5;
+	top: attr(tooltip); left: attr(tooltip); border-radius: 2px; z-index: 20;
+	transform: translate(-5px, 20px);
+    width: 160px; max-width: 160px; position: fixed;
 }
 
 /* 下拉菜单样式 */

--- a/include/game/itemplace.func.php
+++ b/include/game/itemplace.func.php
@@ -190,33 +190,26 @@ function get_item_place($which)
 				$result.="{$area}禁起在商店中出售({$price}元) \r";
 			}
 		}
-	include_once config('mixitem',$gamecfg);
-	global $mixinfo;
-	if(!empty($mixinfo))
+	include config('mixitem',$gamecfg);
+	foreach($mixinfo as $lst)
 	{
-		foreach($mixinfo as $lst)
+		if ($lst['result'][0]==$which || $lst['result'][0]==$which.' ')
 		{
-			if ($lst['result'][0]==$which || $lst['result'][0]==$which.' ')
-			{
-				$result.="通过合成获取 \r";
-				break;
-			}
+			$result.="通过合成获取 \r";
+			break;
 		}
 	}
-	include_once config('vnmixitem',$gamecfg);
-	if(!empty($vn_mixinfo))
+	include config('vnmixitem',$gamecfg);
+	foreach($vn_mixinfo as $vlst)
 	{
-		foreach($vn_mixinfo as $vlst)
+		if ($vlst['result'][0]==$which || $vlst['result'][0]==$which.' ')
 		{
-			if ($vlst['result'][0]==$which || $vlst['result'][0]==$which.' ')
+			$vresult ="通过合成获取 \r";
+			if(strpos($result,$vresult)===false)
 			{
-				$vresult ="通过合成获取 \r";
-				if(strpos($result,$vresult)===false)
-				{
-					$result .= $vresult;
-				}
-				break;
+				$result .= $vresult;
 			}
+			break;
 		}
 	}
 	$file=config('synitem',$gamecfg);

--- a/include/game/revattr.func.php
+++ b/include/game/revattr.func.php
@@ -680,11 +680,12 @@
 				//获取理论消耗体力最大值：
 				$sp_cost_max = $sp_cost_r*$pa['wepe'];
 				//获取实际消耗体力：
-				$sp_cost = min(ceil($sp_cost_max),$pa['sp']-1);
-				$log .= "消耗{$sp_cost}点体力，";
+				$sp_cost = min($sp_cost_max,$pa['sp']-1);
+				$log_sp_cost = round($sp_cost);
+				$log .= "消耗{$log_sp_cost}点体力，";
 			}
 			//获取威力系数：NPC固定为50%
-			$factor = $pa['type'] ? 0.5 : 0.5+($sp_cost/$sp_cost_max/2);
+			$factor = $pa['type'] ? 0.5 : 0.5+round(($sp_cost/$sp_cost_max)/2,1);
 			//获取伤害变化倍率并扣除体力
 			$dmg_p[]= round($factor,2); 
 			$pa['sp'] -= $sp_cost;

--- a/templates/default/vn_records.htm
+++ b/templates/default/vn_records.htm
@@ -18,10 +18,6 @@
 		<td class="b1">$stuff_tips[4]</td>
 		<td class="b1" width="25px"></td>
 		<td class="b1">$result_tips[0]</td>
-		<td class="b1">$result_tips[1]</td>
-		<td class="b1">$result_tips[2]</td>
-		<td class="b1">$result_tips[3]</td>
-		<td class="b1">$log_tips[0]</td>
 		<td class="b1" width="45px">编辑</td>
 		<td class="b1">$log_tips[2]</td>
 	</tr>
@@ -36,10 +32,6 @@
 			<td class="b3"><!--{if isset($cinfo['stuff'][4])}-->$cinfo['stuff'][4]<!--{else}-->-<!--{/if}--></td>
 			<td class="b3"> → </td>
 			<td class="b3">$cinfo['result'][0]</td>
-			<td class="b3">$temp_vniteminfo[$cinfo['result'][1]]</td>
-			<td class="b3">$cinfo['result'][2]</td>
-			<td class="b3">$cinfo['result'][3]</td>
-			<td class="b3"><!--{if isset($cinfo['spkinfo'])}-->$cinfo['spkinfo']<!--{else}-->-<!--{/if}--></td>
 			<td class="b3">
 				<!--{if ($cinfo['name']==$udata['username']||$udata['groupid']>=$vnmix_editor_group||$udata['username']==$gamefounder) && $cinfo['status']!=1}-->
 				<form method="post" action="vn_postitem.php" name="vn_postitem" onsubmit="vn_postitem.php" style="margin: 0px">

--- a/vnworld.php
+++ b/vnworld.php
@@ -57,6 +57,9 @@ if($vnmode=='none')
 						else $temp_carr[$cid]['spkinfo'] = parse_itm_desc($sk,'sk');
 					}
 				}
+				// 汇总合成结果至一段内
+				$temp_carr[$cid]['result'][0] = $cinfo['result'][0].'/'.$temp_vniteminfo[$cinfo['result'][1]].'/'.$cinfo['result'][2].'/'.$cinfo['result'][3];
+				if(isset($temp_carr[$cid]['spkinfo'])) $temp_carr[$cid]['result'][0].='/'.$temp_carr[$cid]['spkinfo'];
 			}
 		}
 	}


### PR DESCRIPTION
修正：
灵力武器系数显示浮动有误的问题；
来源为合成产物的道具在部分页面不能正常显示tooltip的问题；
位于页面边缘的道具tooltip显示不全的问题；
一些情况下空想梦境首页布局变丑的问题；