### PR TITLE
rev combat phase 3.19

### DIFF
--- a/gamedata/cache/clubskills_1.php
+++ b/gamedata/cache/clubskills_1.php
@@ -14,7 +14,7 @@ $club_skillslist = Array
 	6  => Array('s_hp','s_ad','f_heal'), #'宛如疾风',
 	7  => Array('s_hp','s_ad','f_heal'), #'锡安成员',
 	8  => Array('s_hp','s_ad','f_heal'), #'黑衣组织',
-	9  => Array('s_hp','s_ad','f_heal'), #'超能力者',
+	9  => Array('s_hp','s_ad','f_heal','c9_spirit','c9_lb','c9_iceheart','c9_charge','c9_heartfire'), #'超能力者',
 	10 => Array('s_hp','s_ad','f_heal'), #'高速成长',
 	11 => Array('s_hp','s_ad','f_heal'), #'富家子弟',
 	12 => Array('s_hp','s_ad','f_heal'), #'全能骑士',
@@ -352,7 +352,7 @@ $cskills = Array
 		'effect' => Array(
 			0 => Array('skillpara|c2_annihil-active' => '=::1'),
 		),
-		'events' => Array('setstarttimes_c2_annihil','getskill_buff_annihil'),
+		'events' => Array('active_news','setstarttimes_c2_annihil','getskill_buff_annihil'),
 		'link' => Array('buff_annihil'),
 		'vars' => Array(
 			'lasttimes' => 200, //持续时间 仅供介绍文本显示用
@@ -861,6 +861,140 @@ $cskills = Array
 			'skillpara|c5_double-active_t' => '[:skillpara|c5_double-active_t:] < 2',
 			'lvl' => '[:lvl:] >= 19',
 			'wepk+wep_kind' => "[:wepk:] == 'WD' || [:wepk:] == 'WDG' || [:wepk:] == 'WDF' || (!empty([:wep_kind:]) && [:wep_kind:] == 'D')",
+		),
+	),
+	'c9_kotodama' => Array
+	(
+		'name' => '言灵', //未完成
+		'tags' => Array('passive'),
+		'desc' => '使用灵力武器主动攻击敌人时，可通过喊话触发特殊效果<br>
+		升级该技能可解锁更多触发关键词，以下是目前可触发的关键词：',
+		'maxlvl' => 3,
+		'cost' => Array(3,3,4,-1),
+		'input' => '升级',
+		'log' => '<span class="yellow">技能「言灵」升级成功。</span>',
+		'status' => Array('skillpara|c9_kotodama-lvl'),
+		'effect' => Array(
+			0 => Array('skillpara|c9_kotodama-lvl' => '+=::1'),
+		),
+		'svars' => Array(
+			'lvl' => 0, 
+		),
+		'vars' => Array(
+		),
+	),
+	'c9_spirit' => Array
+	(
+		'name' => '灵力',
+		'tags' => Array('passive'),
+		'desc' => '敌人攻击你时，其命中率降低<span class="yellow">[:accloss:]%</span>，连击命中率惩罚<span class="yellow">+[:rbloss:]%</span><br>
+		你使用灵系武器的体力消耗降低<span class="yellow">[:spcloss:]%</span>',
+		'maxlvl' => 3,
+		'cost' => Array(3,3,4,-1),
+		'input' => '升级',
+		'log' => '<span class="yellow">技能「灵力」升级成功。</span>',
+		'status' => Array('skillpara|c9_spirit-lvl'),
+		'effect' => Array(
+			0 => Array('skillpara|c9_spirit-lvl' => '+=::1'),
+		),
+		'svars' => Array(
+			'lvl' => 0, //初次获得时等级为0
+		),
+		'vars' => Array(
+			'accloss' => Array(0,4,8,12), 
+			'rbloss' => Array(0,2,3,4),
+			'spcloss' => Array(40,50,60,70),
+		),
+	),
+	'c9_lb' => Array
+	(
+		'name' => '必杀',
+		'tags' => Array('battle'),
+		'desc' => '本次攻击造成物理伤害<span class="yellow">×[:phydmgr:]</span><br>
+		消耗<span class="yellow">[:ragecost:]</span>点怒气，若拥有<span class="yellow">重击辅助</span>属性会额外返还<span class="yellow">[:rageback:]</span>点怒气',
+		'bdesc' => '本次攻击物理伤害<span class="yellow">×[:phydmgr:]</span>，消耗<span class="red">[:ragecost:]</span>怒气',
+		'vars' => Array(
+			'ragecost' => 40,
+			'rageback' => 6,
+			'phydmgr' => 2, 
+		),
+		'lockdesc' => Array(
+			'lvl' => '3级时解锁',
+		),
+		'unlock' => Array(
+			'lvl' => '[:lvl:] >= 3',
+		),
+	),
+	'c9_iceheart' => Array
+	(
+		'name' => '冰心',
+		'tags' => Array('passive'),
+		'desc' => '使用灵力武器攻击时，你受到的反噬伤害降低<span class="yellow">[:hpshloss:]%</span><br>
+		受到伤害时，即刻解除<span class="yellow">[:purify:]</span>个异常/受伤状态。<br>
+		每通过技能解除1个异常/受伤状态，你的怒气提升<span class="yellow">[:ragegain:]</span>点',
+		'vars' => Array(
+			'hpshloss' => 80,
+			'purify' => 1, 
+			'ragegain' => 40, 
+		),
+		'lockdesc' => Array(
+			'lvl' => '7级时解锁',
+			'wepk+wep_kind' => '武器不适用，持<span class="yellow">灵力武器</span>时生效',
+		),
+		'unlock' => Array(
+			'lvl' => '[:lvl:] >= 7',
+			'wepk+wep_kind' => "[:wepk:] == 'WF' || [:wepk:] == 'WCF' || [:wepk:] == 'WKF' || [:wepk:] == 'WFK' || [:wepk:] == 'WDF' || (!empty([:wep_kind:]) && [:wep_kind:] == 'F')",
+		),
+	),
+	'c9_charge' => Array
+	(
+		'name' => '充能',
+		'tags' => Array('cd'),
+		'desc' => '发动后立即增加<span class="yellow">[:rageadd:]</span>点怒气。<br>
+		前<span class="yellow">[:freet:]</span>次发动没有冷却时间，之后每次发动冷却时间<span class="clan">[:cd:]</span>秒<br>
+		本局已发动：<span class="yellow">[^skillpara|c9_charge-active_t^]</span>次',
+		'input' => '发动',
+		'log' => '<span class="lime">技能「充能」发动成功。</span><br>',
+		'events' => Array('charge','active_news'),
+		'status' => Array('skillpara|c9_charge-active_t'),
+		'effect' => Array(
+			0 => Array('skillpara|c9_charge-active_t' => '+=::1'),
+		),
+		'svars' => Array(
+			'active_t' => 0,
+		),
+		'vars' => Array(
+			'rageadd' => 100, 
+			'freet' => 2,
+			'cd' => 600, //冷却时间
+		),
+		'pvars' => Array(
+			'skillpara|c9_charge-active_t',
+		),
+		'lockdesc' => Array(
+			'lvl' => '11级时解锁',
+			'skillcooldown' => '技能冷却中！<br>剩余冷却时间：<span class="red">[:cd:]</span> 秒',
+		),
+		'unlock' => Array(
+			'lvl' => '[:lvl:] >= 11',
+			'skillcooldown' => 0,
+		),
+	),
+	'c9_heartfire' => Array
+	(
+		'name' => '心火',
+		'tags' => Array('battle'),
+		'desc' => '本次攻击造成的最终伤害<span class="yellow">×[:findmgr:]</span>。消耗<span class="yellow">[:ragecost:]</span>点怒气<br>',
+		'bdesc' => '本次攻击最终伤害<span class="yellow">×[:findmgr:]</span>，消耗<span class="red">[:ragecost:]</span>怒气',
+		'vars' => Array(
+			'ragecost' => 60,
+			'findmgr' => 2, 
+		),
+		'lockdesc' => Array(
+			'lvl' => '19级时解锁',
+		),
+		'unlock' => Array(
+			'lvl' => '[:lvl:] >= 19',
 		),
 	),
 	'tl_cstick' => Array

--- a/gamedata/cache/evonpc_1.php
+++ b/gamedata/cache/evonpc_1.php
@@ -68,6 +68,21 @@ $enpcinfo = array
 			'gd' => 'f',
 			'icon' => 62,
 			'club' => 4,
+			'clubskill' => Array(),
+			'clubskillpara' => Array
+			(
+				'c4_stable' => Array(
+					'lvl' => 3,
+					'costcount' => 7,
+				),
+				'c4_break' => Array(
+					'lvl' => 1,
+					'costcount' => 6,
+				),
+				'c4_sniper' => Array(
+					'active' => 1,
+				),
+			),
 			'inf' => '',
 			'rage' => 225,
 			'state' => 1,
@@ -123,6 +138,21 @@ $enpcinfo = array
 			'gd' => 'f',
 			'icon' => 64,
 			'club' => 4,
+			'clubskill' => Array(),
+			'clubskillpara' => Array
+			(
+				'c4_stable' => Array(
+					'lvl' => 2,
+					'costcount' => 4,
+				),
+				'c4_break' => Array(
+					'lvl' => 1,
+					'costcount' => 6,
+				),
+				'c4_roar' => Array(
+					'active' => 1,
+				),
+			),
 			'inf' => '',
 			'rage' => 225,
 			'state' => 1,

--- a/gamedata/cache/resources_1.php
+++ b/gamedata/cache/resources_1.php
@@ -244,6 +244,7 @@ $lwinfo = Array(
 	92 => '成为……焰火……',
 );
 $infinfo = Array('b' => '<span class="red">胸</span>', 'h' => '<span class="red">头</span>', 'a' => '<span class="red">腕</span>', 'f' => '<span class="red">足</span>', 'p' => '<span class="purple">毒</span>', 'u' => '<span class="red">烧</span>', 'i' => '<span class="clan">冻</span>', 'e' => '<span class="yellow">麻</span>','w' => '<span class="grey">乱</span>');
+$dtinfinfo = Array('b' => '<span class="red">胸部受伤</span>', 'h' => '<span class="red">头部受伤</span>', 'a' => '<span class="red">腕部受伤</span>', 'f' => '<span class="red">足部受伤</span>', 'p' => '<span class="purple">中毒</span>', 'u' => '<span class="red">烧伤</span>', 'i' => '<span class="clan">冻结</span>', 'e' => '<span class="yellow">麻痹</span>','w' => '<span class="grey">混乱</span>');
 $attinfo = Array('N' => '徒手殴打', 'P' => '殴打','K' => '斩刺', 'G' => '射击', 'C' => '投掷', 'D' => '设置引信伏击', 'F' => '释放灵力攻击', 'J' => '狙击');
 $skillinfo = Array('N' => 'wp', 'P' => 'wp', 'K' => 'wk', 'G' => 'wg', 'C' => 'wc', 'D' => 'wd', 'F'=> 'wf', 'J'=> 'wg');
 //$rangeinfo = Array('N' => 'S', 'P' => 'S', 'K' => 'S', 'G' => 'M', 'C' => 'M', 'D' => 'L', 'F'=> 'M'); #各种攻击方式的射程，移动到combatcfg.php
@@ -1157,7 +1158,7 @@ $tps_isk = Array
 	'B' => Array('title' => "极高概率将全部物理伤害变为1。",),
 	'b' => Array('title' => "极高概率将全部属性伤害变为1。",),
 	'C' => Array('title' => "高概率将投系对你的物理伤害减半。",),
-	'c' => Array('title' => "降低重击与必杀技的怒气消耗，以及重击概率。",),
+	'c' => Array('title' => "攻击时额外获得1点怒气，发动战斗技时会返还10%消耗的怒气",),
 	'D' => Array('title' => "高概率将爆系对你的物理伤害，以及爆炸属性伤害减半。",),
 	'd' => Array('title' => "攻击对手时，将产生额外的爆炸属性伤害。",),
 	'E' => Array('title' => "高概率将电击属性对你的属性伤害减半。并避免身体麻痹状态。",),

--- a/include/game/clubslct.func.php
+++ b/include/game/clubslct.func.php
@@ -86,7 +86,7 @@ function updateskill(&$data=NULL)
 	
 	# 变更社团时 获取社团技能
 	//include_once GAME_ROOT.'./include/game/revclubskills.func.php';
-	if(empty($data))
+	if(!isset($data))
 	{
 		$cks = $club_skillslist[$club];
 		foreach($cks as $sk) getclubskill($sk,$clbpara);

--- a/include/game/itemmain.func.php
+++ b/include/game/itemmain.func.php
@@ -101,7 +101,7 @@ function check_trap_def_event(&$pa,$damage,$playerflag=0,$selflag=0)
 function calc_trap_reuse_rate($pa,$playerflag=0,$selflag=0)
 {
 	# 基础回收率
-	$fdrate = 5 + $lvl/3;
+	$fdrate = 5 + $pa['lvl']/3;
 	# 拆弹专家社团加成
 	if($pa['club'] == 5) $fdrate += 35;
 	# 自雷回收加成
@@ -1192,7 +1192,7 @@ function getcorpse($item){
 
 	if($item == 'destory')
 	{
-		if(!$allow_destory_corpse || in_array($edata['tyep'],$no_destory_corpse_type))
+		if(!$allow_destory_corpse || in_array($edata['type'],$no_destory_corpse_type))
 		{
 			$log.="你还想对这具可怜的尸体干什么？麻烦给死者一点基本的尊重！<br>";
 			$action = '';

--- a/include/game/revclubskills.func.php
+++ b/include/game/revclubskills.func.php
@@ -178,9 +178,15 @@
 	}
 
 	# 升级指定技能会触发的事件，返回0时代表无法升级技能
-	function upgclbskills_events($event,$sk)
+	function upgclbskills_events($event,$sk,$data=NULL)
 	{
-		global $log,$cskills,$clbpara;
+		global $log,$cskills,$clbpara,$name;
+		# 事件：激活技能
+		if($event == 'active_news')
+		{
+			addnews($now,'ask_'.$sk,$name);
+			return 1;
+		}
 		# 事件：治疗
 		if($event == 'heal')
 		{
@@ -205,6 +211,28 @@
 				return 0;
 			}
 			return 1;
+		}
+		# 事件：怒气充能
+		if($event == 'charge')
+		{
+			global $rage;
+			if($rage >= 255)
+			{
+				$log .= "你不需要使用这个技能！<br>";
+				return 0;
+			}
+			$rage = min(255,$rage + get_skillvars('c9_charge','rageadd'));
+			// 检查当前技能使用次数
+			$active_t = get_skillpara('c9_charge','active_t',$clbpara);
+			// 第3次使用时开始冷却
+			if($active_t+1 > get_skillvars('c9_charge','freet'))
+			{
+				$event = 'setstarttimes_c9_charge';
+			}
+			else 
+			{
+				return 1;
+			}
 		}
 		# 事件：获取指定技能
 		if(strpos($event,'getskill_') === 0)

--- a/include/game/revcombat.func.php
+++ b/include/game/revcombat.func.php
@@ -1037,6 +1037,18 @@
 			{
 				$pa_rgup = rand(1,2);
 				$pa['rage'] = min(255,$pa['rage']+$pa_rgup);
+				# 成功发动战斗技时，额外返还10%怒气
+				if(isset($pa['bskill']) && isset($pa['bskill_'.$pa['bskill']]))
+				{
+					$bsk = $pa['bskill'];
+					$bsk_cost = get_skillvars($bsk,'ragecost');
+					if($bsk_cost)
+					{
+						$pa['rage'] += round($bsk_cost*0.1);
+						# 必杀技能额外返还15点怒气
+						if($bsk == 'c9_lb') $pa['rage'] += get_skillvars('c9_lb','rageback');
+					}
+				}
 			}
 		}
 		# 无论攻击是否命中，计算pd(防守方)因挨打获得的怒气

--- a/include/news.func.php
+++ b/include/news.func.php
@@ -317,6 +317,10 @@ function  nparse_news($start = 0, $range = 0  ){//$type = '') {
 			$newsinfo .= "<li>{$hour}时{$min}分{$sec}秒，<span class=\"orange\">{$a}发送了控制指令，全部禁区解除！</span><br>\n";
 		} elseif($news == 'csl_addarea') {
 			$newsinfo .= "<li>{$hour}时{$min}分{$sec}秒，<span class=\"orange\">{$a}发送了控制指令，下一回禁区提前到来了！</span><br>\n";
+		} elseif(strpos($news,'ask_')===0) {
+			$ask = substr($news,4);
+			$aname = $cskills[$ask]['name'];
+			$newsinfo .= "<li>{$hour}时{$min}分{$sec}秒，<span class=\"lime\">{$a}发动了技能<span class=\"yellow\">「{$aname}」</span>！</span><br>\n";
 		} elseif(strpos($news,'bsk_')===0) {
 			$bsk = substr($news,4);
 			$bname = $cskills[$bsk]['name'];

--- a/include/system.func.php
+++ b/include/system.func.php
@@ -687,6 +687,29 @@ function addnpc($type,$sub,$num,$time = 0,$clbstatus=NULL,$aitem=NULL,$apls=NULL
 				}
 				//$npc['pls'] = rand(1,$plsnum-1);
 			}	
+			# NPC技能初始化
+			// 社团技能初始化
+			global $club_skillslist;
+			if(isset($club_skillslist[$npc['club']]))
+			{
+				if(empty($npc['clbpara'])) $npc['clbpara']['skill'] = Array();
+				$npc_csk = $club_skillslist[$npc['club']];
+				foreach($npc_csk as $sk) getclubskill($sk,$npc['clbpara']);
+			}
+			// 自定技能初始化
+			global $cskills;
+			if(!empty($npc['clubskill']))
+			{
+				foreach($npc['clubskill'] as $sk) getclubskill($sk,$npc['clbpara']);
+			}
+			// 自定技能参数初始化
+			if(!empty($npc['clubskillpara']))
+			{
+				foreach($npc['clubskillpara'] as $sk => $skarr)
+				{
+					foreach($skarr as $skpara => $skvalue) set_skillpara($sk,$skpara,$skvalue,$npc['clbpara']);
+				}
+			}
 			//自定义addnpc出现位置，会覆盖原本预设的位置。 TODO：要不要发个特别的news？
 			if(isset($apls)) $npc['pls'] = (int)$apls;
 			//自定义addnpc身上携带的道具，会覆盖原本预设的道具。 格式：$aitem=Array($iid=>Array($itm,$itmk,$itme,$itms,$itmsk),...)
@@ -758,6 +781,33 @@ function evonpc($type,$name){
 	$npc['wp'] = $npc['wk'] = $npc['wg'] = $npc['wc'] = $npc['wd'] = $npc['wf'] = $npc['skill'];
 	unset($npc['skill']);
 	$qry = '';
+	# NPC进化后技能初始化
+	// 社团技能初始化
+	global $club_skillslist;
+	if(isset($club_skillslist[$npc['club']]))
+	{
+		if(empty($npc['clbpara'])) $npc['clbpara']['skill'] = Array();
+		$npc_csk = $club_skillslist[$npc['club']];
+		foreach($npc_csk as $sk) getclubskill($sk,$npc['clbpara']);
+	}
+	// 自定技能初始化
+	global $cskills;
+	if(!empty($npc['clubskill']))
+	{
+		foreach($npc['clubskill'] as $sk) getclubskill($sk,$npc['clbpara']);
+	}
+	// 自定技能参数初始化
+	if(!empty($npc['clubskillpara']))
+	{
+		foreach($npc['clubskillpara'] as $sk => $skarr)
+		{
+			foreach($skarr as $skpara => $skvalue) set_skillpara($sk,$skpara,$skvalue,$npc['clbpara']);
+		}
+	}
+	unset($npc['clubskill']);unset($npc['clubskillpara']);
+	# todo:整理下这堆烂摊子
+	$npc['clbpara'] = json_encode($npc['clbpara']);
+	//$npc = player_format_with_db_structure($npc);
 	foreach($npc as $key => $val){
 		$qry .= "$key = '{$val}',";
 	}

--- a/templates/default/rankinfo.htm
+++ b/templates/default/rankinfo.htm
@@ -2,8 +2,8 @@
 	<TR height="20">
 		<TD class="b1" width="30px"><span>排名</span></TD>
 		<TD class="b1" width="45px"><span>UID</span></TD>
+		<TD class="b1" width="95px"><span>{lang nick}</span></TD>
 		<TD class="b1" width="95px"><span>{lang name}</span></TD>
-		<TD class="b1" width="75px"><span>{lang nick}</span></TD>
 		<TD class="b1" width="35px"><span>{lang gender}</span></TD>
 		<TD class="b1" width="80px"><span>{lang icon}</span></TD>
 		<TD class="b1" style="maxwidth:120"><span>{lang motto}</span></TD>
@@ -18,8 +18,8 @@
 	<TR height="20">
 		<TD class="b2"><span><!--{if $urdata['number']==1}--><a title="触手！"><span class="red">榜首</span></a><!--{elseif $urdata['number']<=10}--><span class="yellow">$urdata['number']</span><!--{else}-->$urdata['number']<!--{/if}--></span></TD>
 		<TD class="b3"><span>$urdata['uid']</span></TD>
-		<TD class="b3"><span><u><a href="user_profile.php?playerID=$urdata['username']">$urdata['username']</a></u></span></TD>
 		<TD class="b3"><span>$urdata['nickinfo']</span></TD>
+		<TD class="b3"><span><u><a href="user_profile.php?playerID=$urdata['username']">$urdata['username']</a></u></span></TD>
 		<TD class="b3"><span><!--{if $urdata['gender']}-->$sexinfo[$urdata['gender']]<!--{else}-->$sexinfo[0]<!--{/if}--></span></TD>
 		<TD class="b3"><span><IMG src="img/$urdata['img']" width="70" height="40" border="0" align="absmiddle"></span></TD>
 		<TD class="b3"><span>$urdata['motto']</span></TD>

--- a/templates/default/skill_temp.htm
+++ b/templates/default/skill_temp.htm
@@ -3,6 +3,8 @@
 <!--{eval $cskill = $cskills[$skid];}-->
 <!--{if isset($cskill['maxlvl'])}-->
     <!--{eval $now_clvl = get_skilllvl($skid,$uidata); $max_lvl_flag = $now_clvl >= $cskill['maxlvl'] ? 1 : 0;}-->
+<!--{else}-->
+    <!--{eval $max_lvl_flag = 0;}-->
 <!--{/if}-->
 <tr>
     <td class="b1" width="40">
@@ -43,12 +45,11 @@
                     <td valign="center" align="center">
                         <span class="yellow">
                             <!-- 未满足解锁条件时显示的文本，自己填或使用下面的方式 -->
-                            <!--{eval $skid_lockdesc = $cskill['lockdesc'][$unlock_flag];}-->
                             <!--{if is_array($unlock_flag)}-->
                                 <!--{eval $unlock_cd = $unlock_flag[1]; $unlock_flag = $unlock_flag[0]; $unlock_flag = str_replace("[:cd:]","$unlock_cd",$unlock_flag);}-->
                             <!--{/if}-->
                             <!--{eval $unlock_flag = is_array($cskill['lockdesc']) ? $cskill['lockdesc'][$unlock_flag] : $cskill['lockdesc']; $unlock_flag = isset($unlock_cd) ? str_replace("[:cd:]","$unlock_cd",$unlock_flag) : $unlock_flag;}-->
-                            <span class="yellow">$skid_lockdesc</span>
+                            $unlock_flag
                         </span>
                     </td>
                 </tr>

--- a/templates/default/winnerlist.htm
+++ b/templates/default/winnerlist.htm
@@ -8,7 +8,7 @@
 		<TR height="20">
 			<TD class="b1" width="30px"><span>回</span></TD>
 			<TD class="b1" width="60px"><span>胜利方式</span></TD>
-			<TD class="b1" width="75px"><span>头衔</span></TD>
+			<TD class="b1" width="95px"><span>头衔</span></TD>
 			<TD class="b1" width="95px"><span>优胜者名</span></TD>
 			<TD class="b1" width="80px"><span>头像</span></TD>
 			<TD class="b1"><span>游戏结束时间</span></TD>

--- a/valid.php
+++ b/valid.php
@@ -124,7 +124,9 @@ if($mode == 'enter') {
 	//$itm[6] = '银白盒子'; $itmk[6] = 'p'; $itme[6] = 1; $itms[6] = 1; $itmsk[6] = 'ps';
 	$itm[5] = '秋刀鱼罐头'; $itmk[5] = 'HB'; $itme[5] = 70; $itms[5] = 15;
 	//$itm[5] = 'GRAND OPENING 「开门大吉」'; $itmk[5] = 'p000'; $itme[5] = 1; $itms[5] = 1;
-	$dice = rand(1,5); $dice_name = $clubinfo[$dice];
+	$dice = rand(1,6); 
+	if($dice == 6) $dice = 9;
+	$dice_name = $clubinfo[$dice];
 	$itm[5] = '「'.$dice_name.' 社团卡」'; $itmk[5] = 'ZB'; $itme[5] = $dice; $itms[5] = 1;
 
 	if ($wingames <=1){


### PR DESCRIPTION
战斗系统革新 阶段3.19：

- 怒气技能系统： 移植回「超能力者」社团的怒气技能；
为「超能力者」社团增加技能「冰心」；
现在NPC将会在先制攻击时释放战斗技；
现在发动「歼灭」「充能」等主动技时会向进行状况发送news；
- 删除了自动重击与喊话必杀机制；
- 现在「重击辅助」属性的效果变更为：攻击时额外获得1点怒气，发动战斗技时会返还10%消耗的怒气；