### PR TITLE
Fix RuleSet configuration collision

### DIFF
--- a/doc/20260807-132827-fix-ruleset-config-collision.txt
+++ b/doc/20260807-132827-fix-ruleset-config-collision.txt
@@ -1,0 +1,16 @@
+时光重现房间列表配置污染修复 / Fix RuleSet room-list configuration collision
+
+问题 / Problem
+- 当房间列表中已有时光重现房间时，模板会把全局 $ruleset_config 覆盖为单个 RuleSet 配置。
+- 随后同一请求再次取得完整配置时，name、credits_cost 等字段被误作为 RuleSet 条目，导致字符串/整数数组偏移警告和损坏的创建界面。
+- 临时调试代码还会向测试服不存在的 doc/etc 目录写文件，产生额外 Warning。
+
+修复 / Fix
+- 新增独立的 $ruleset_definitions 注册表，get_ruleset_config() 只从该注册表读取完整配置。
+- 对 RuleSet 条目进行形状校验，并让 can_create_ruleset_room() 安全拒绝无效 ID 或损坏配置。
+- 将页面、入场和 API 中单个 RuleSet 的临时变量改为专用名称，避免再次覆盖全局注册表。
+- 移除房间创建权限检查中的临时 file_put_contents 调试写入。
+
+验证 / Verification
+- 使用 C:\Soft\php-7.4.33-nts-Win32-vc15-x64\php.exe 对受影响 PHP 文件执行语法检查。
+- 覆盖“旧模板仍写入 $ruleset_config”的回归场景，确认七个 RuleSet 仍完整可用、无效字段 ID 被拒绝、管理员/普通用户权限正确，且不会生成调试文件。

--- a/gamedata/ruleset/ruleset_config.php
+++ b/gamedata/ruleset/ruleset_config.php
@@ -6,7 +6,7 @@ if(!defined('IN_GAME')) {
 
 // 本文件经常在函数体内被 include_once；显式绑定全局作用域，避免配置只落入调用函数的局部变量。
 // This file is often include_once'd inside functions; bind globals explicitly so config remains visible.
-global $ruleset_enabled, $ruleset_config;
+global $ruleset_enabled, $ruleset_config, $ruleset_definitions;
 
 /*
  * RuleSet系统（时光重现）配置文件
@@ -428,16 +428,32 @@ $ruleset_config = Array(
 );
 
 
+// 保留独立的完整注册表，避免页面/流程中的单条配置临时变量覆盖它。
+// Keep the canonical registry separate from per-ruleset temporary variables.
+$ruleset_definitions = $ruleset_config;
+
+
+// 校验单个RuleSet配置，防止错误数据进入房间列表或创建流程。
+// Validate one RuleSet entry before it reaches room-list or creation code.
+function ruleset_config_entry_is_valid($config) {
+    return is_array($config)
+        && isset($config['name']) && is_string($config['name'])
+        && isset($config['description']) && is_string($config['description'])
+        && isset($config['credits_cost']) && is_numeric($config['credits_cost'])
+        && array_key_exists('admin_free', $config);
+}
 
 // 获取RuleSet配置的函数
 function get_ruleset_config($ruleset_id = null) {
-    // 直接在函数内部定义配置，避免全局变量作用域问题
-    $local_ruleset_enabled = true;
+    // 使用独立注册表，不能读取可被调用方复用的 $ruleset_config 临时变量。
+    // Use the dedicated registry instead of the caller-reusable $ruleset_config variable.
+    global $ruleset_enabled, $ruleset_definitions;
+    $local_ruleset_enabled = !empty($ruleset_enabled);
 
-    // 尝试使用全局配置，如果不存在则使用本地配置
-    global $ruleset_config;
-    if (isset($ruleset_config) && is_array($ruleset_config)) {
-        $local_ruleset_config = $ruleset_config;
+    // 尝试使用独立的全局注册表，如果不存在则使用本地配置。
+    // Prefer the isolated global registry; use the local fallback only when unavailable.
+    if (isset($ruleset_definitions) && is_array($ruleset_definitions)) {
+        $local_ruleset_config = $ruleset_definitions;
     } else {
         // 如果全局变量不存在，使用本地配置作为fallback
         $local_ruleset_config = Array(
@@ -536,8 +552,20 @@ function get_ruleset_config($ruleset_id = null) {
         return false;
     }
 
+    // 过滤损坏或不完整的条目，避免模板将标量误作配置数组。
+    // Filter malformed entries so templates never treat scalars as configuration arrays.
+    foreach ($local_ruleset_config as $local_ruleset_id => $local_config) {
+        if (!ruleset_config_entry_is_valid($local_config)) {
+            unset($local_ruleset_config[$local_ruleset_id]);
+        }
+    }
+
     if ($ruleset_id === null) {
         return $local_ruleset_config;
+    }
+
+    if (!is_string($ruleset_id) && !is_int($ruleset_id)) {
+        return false;
     }
 
     return isset($local_ruleset_config[$ruleset_id]) ? $local_ruleset_config[$ruleset_id] : false;
@@ -545,72 +573,21 @@ function get_ruleset_config($ruleset_id = null) {
 
 // 检查用户是否可以创建指定RuleSet房间
 function can_create_ruleset_room($ruleset_id, $user_data) {
-    // 使用get_ruleset_config函数获取配置，确保一致性
-    $local_ruleset_enabled = true;
-    $local_ruleset_config = get_ruleset_config();
-
-    // 调试信息：记录函数内部状态
-    $debug_info = array(
-        'function_called' => 'can_create_ruleset_room',
-        'ruleset_id' => $ruleset_id,
-        'user_data_groupid' => isset($user_data['groupid']) ? $user_data['groupid'] : 'undefined',
-        'user_data_credits2' => isset($user_data['credits2']) ? $user_data['credits2'] : 'undefined',
-        'local_ruleset_enabled' => $local_ruleset_enabled,
-        'local_config_exists' => isset($local_ruleset_config[$ruleset_id]) ? 'yes' : 'no',
-        'fix_method' => 'using_local_config'
-    );
-
-    if (!$local_ruleset_enabled || !isset($local_ruleset_config[$ruleset_id])) {
-        $debug_info['early_return'] = 'ruleset_disabled_or_config_missing';
-        $debug_info['enabled_check'] = $local_ruleset_enabled ? 'pass' : 'fail';
-        $debug_info['config_exists_check'] = isset($local_ruleset_config[$ruleset_id]) ? 'pass' : 'fail';
-
-        // 写入调试文件
-        file_put_contents(GAME_ROOT.'./doc/etc/can_create_debug_'.date('Y-m-d_H-i-s').'.txt',
-            "can_create_ruleset_room调试信息:\n" . print_r($debug_info, true));
-
+    $config = get_ruleset_config($ruleset_id);
+    if (!is_array($user_data) || !ruleset_config_entry_is_valid($config)) {
         return false;
     }
 
-    $config = $local_ruleset_config[$ruleset_id];
-    $debug_info['config_admin_free'] = $config['admin_free'];
-    $debug_info['config_credits_cost'] = $config['credits_cost'];
+    $groupid = isset($user_data['groupid']) && is_scalar($user_data['groupid']) ? intval($user_data['groupid']) : 0;
+    $credits2 = isset($user_data['credits2']) && is_scalar($user_data['credits2']) ? intval($user_data['credits2']) : 0;
+    $credits_cost = max(0, intval($config['credits_cost']));
 
-    // 管理员免费 (修改权限要求从>=4改为>=2，允许所有管理员免费创建)
-    if ($config['admin_free'] && $user_data['groupid'] >= 2) {
-        $debug_info['result'] = 'admin_pass';
-        $debug_info['admin_free_check'] = $config['admin_free'] ? 'pass' : 'fail';
-        $debug_info['groupid_check'] = ($user_data['groupid'] >= 2) ? 'pass' : 'fail';
-
-        // 写入调试文件
-        file_put_contents(GAME_ROOT.'./doc/etc/can_create_debug_'.date('Y-m-d_H-i-s').'.txt',
-            "can_create_ruleset_room调试信息:\n" . print_r($debug_info, true));
-
+    // 管理员免费（groupid >= 2）。 / Administrators (groupid >= 2) create for free.
+    if (!empty($config['admin_free']) && $groupid >= 2) {
         return true;
     }
 
-    // 检查切糕数量
-    if ($user_data['credits2'] >= $config['credits_cost']) {
-        $debug_info['result'] = 'credits_pass';
-        $debug_info['credits_check'] = ($user_data['credits2'] >= $config['credits_cost']) ? 'pass' : 'fail';
-
-        // 写入调试文件
-        file_put_contents(GAME_ROOT.'./doc/etc/can_create_debug_'.date('Y-m-d_H-i-s').'.txt',
-            "can_create_ruleset_room调试信息:\n" . print_r($debug_info, true));
-
-        return true;
-    }
-
-    $debug_info['result'] = 'all_checks_failed';
-    $debug_info['admin_free_check'] = $config['admin_free'] ? 'pass' : 'fail';
-    $debug_info['groupid_check'] = ($user_data['groupid'] >= 2) ? 'pass' : 'fail';
-    $debug_info['credits_check'] = ($user_data['credits2'] >= $config['credits_cost']) ? 'pass' : 'fail';
-
-    // 写入调试文件
-    file_put_contents(GAME_ROOT.'./doc/etc/can_create_debug_'.date('Y-m-d_H-i-s').'.txt',
-        "can_create_ruleset_room调试信息:\n" . print_r($debug_info, true));
-
-    return false;
+    return $credits2 >= $credits_cost;
 }
 
 // 获取RuleSet资源文件路径

--- a/include/roommng.func.php
+++ b/include/roommng.func.php
@@ -169,27 +169,6 @@ function roommng_create_new_room(&$udata, $ruleset_id = '')
 			// 包含配置文件
 			include_once GAME_ROOT.'./gamedata/ruleset/ruleset_config.php';
 
-			// 调试信息：记录权限检查过程
-			$debug_info = array(
-				'ruleset_id' => $ruleset_id,
-				'user_groupid' => $udata['groupid'],
-				'user_credits2' => $udata['credits2'],
-				'ruleset_enabled' => isset($ruleset_enabled) ? $ruleset_enabled : 'undefined',
-				'config_exists' => isset($ruleset_config[$ruleset_id]) ? 'yes' : 'no'
-			);
-
-			if(isset($ruleset_config[$ruleset_id])) {
-				$config = $ruleset_config[$ruleset_id];
-				$debug_info['admin_free'] = $config['admin_free'];
-				$debug_info['credits_cost'] = $config['credits_cost'];
-				$debug_info['admin_check'] = ($config['admin_free'] && $udata['groupid'] >= 2) ? 'pass' : 'fail';
-				$debug_info['credits_check'] = ($udata['credits2'] >= $config['credits_cost']) ? 'pass' : 'fail';
-			}
-
-			// 临时调试：将调试信息写入文件
-			file_put_contents(GAME_ROOT.'./doc/etc/ruleset_debug_'.date('Y-m-d_H-i-s').'.txt',
-				"RuleSet权限检查调试信息:\n" . print_r($debug_info, true));
-
 			if(!can_create_ruleset_room($ruleset_id, $udata))
 			{
 				$rerror = 'ruleset_no_permission';
@@ -197,7 +176,7 @@ function roommng_create_new_room(&$udata, $ruleset_id = '')
 			}
 
 			$config = get_ruleset_config($ruleset_id);
-			if($config && !($config['admin_free'] && $udata['groupid'] >= 2))
+			if($config && !(!empty($config['admin_free']) && $udata['groupid'] >= 2))
 			{
 				$ruleset_cost = max(0, intval($config['credits_cost']));
 			}

--- a/index.php
+++ b/index.php
@@ -97,8 +97,8 @@ else
 
       // 添加RuleSet信息
       if (!empty($rinfo['gruleset'])) {
-        $ruleset_config = get_ruleset_config($rinfo['gruleset']);
-        $room['ruleset'] = $ruleset_config ? $ruleset_config['name'] : $rinfo['gruleset'];
+        $room_ruleset_config = get_ruleset_config($rinfo['gruleset']);
+        $room['ruleset'] = $room_ruleset_config ? $room_ruleset_config['name'] : $rinfo['gruleset'];
       } else {
         $room['ruleset'] = '';
       }

--- a/templates/default/roomlist.htm
+++ b/templates/default/roomlist.htm
@@ -33,9 +33,9 @@
 				<td class="b3" width="100px">
 					<!--{if !empty($rinfo['gruleset'])}-->
 						<!--{eval include_once GAME_ROOT.'./gamedata/ruleset/ruleset_config.php';}-->
-						<!--{eval $ruleset_config = get_ruleset_config($rinfo['gruleset']);}-->
-						<!--{if $ruleset_config}-->
-							<span class="yellow" title="$ruleset_config[description]">$ruleset_config[name]</span>
+						<!--{eval $room_ruleset_config = get_ruleset_config($rinfo['gruleset']);}-->
+						<!--{if $room_ruleset_config}-->
+							<span class="yellow" title="$room_ruleset_config[description]">$room_ruleset_config[name]</span>
 						<!--{else}-->
 							<span class="red">$rinfo[gruleset]</span>
 						<!--{/if}-->

--- a/templates/default/user.htm
+++ b/templates/default/user.htm
@@ -8,9 +8,9 @@
 		<!--{eval $ruleset_id = $room_data['gruleset'];}-->
 		<!--{if !empty($ruleset_id)}-->
 			<!--{eval include_once GAME_ROOT.'./gamedata/ruleset/ruleset_config.php';}-->
-			<!--{eval $ruleset_config = get_ruleset_config($ruleset_id);}-->
-			<!--{if $ruleset_config && isset($ruleset_config['avatar_config']) && $ruleset_config['avatar_config']['use_ruleset_avatars']}-->
-				window.rulesetAvatarPath = '$ruleset_config[avatar_config][avatar_path]';
+			<!--{eval $user_ruleset_config = get_ruleset_config($ruleset_id);}-->
+			<!--{if $user_ruleset_config && isset($user_ruleset_config['avatar_config']) && $user_ruleset_config['avatar_config']['use_ruleset_avatars']}-->
+				window.rulesetAvatarPath = '$user_ruleset_config[avatar_config][avatar_path]';
 			<!--{/if}-->
 		<!--{/if}-->
 	<!--{/if}-->

--- a/valid.php
+++ b/valid.php
@@ -217,9 +217,9 @@ if($mode == 'enter') {
 	# 应用RuleSet初始化设置
 	if (!empty($ruleset_id)) {
 		include_once GAME_ROOT.'./gamedata/ruleset/ruleset_config.php';
-		$ruleset_config = get_ruleset_config($ruleset_id);
-		if ($ruleset_config && !empty($ruleset_config['initial_setup'])) {
-			$setup = $ruleset_config['initial_setup'];
+		$active_ruleset_config = get_ruleset_config($ruleset_id);
+		if ($active_ruleset_config && !empty($active_ruleset_config['initial_setup'])) {
+			$setup = $active_ruleset_config['initial_setup'];
 
 			# 应用初始属性设置
 			if (isset($setup['hp_limit'])) $mhp = $hp = $setup['hp_limit'];
@@ -256,8 +256,8 @@ if($mode == 'enter') {
 			}
 
 			# 设置开场剧情
-			if (!empty($ruleset_config['story_config']['opening_story'])) {
-				$clbpara['ruleset_opening_story'] = $ruleset_config['story_config']['opening_story'];
+			if (!empty($active_ruleset_config['story_config']['opening_story'])) {
+				$clbpara['ruleset_opening_story'] = $active_ruleset_config['story_config']['opening_story'];
 			}
 		}
 	}


### PR DESCRIPTION
## 修复内容

- 将完整 RuleSet 注册表与页面中单个 RuleSet 的临时变量隔离。
- 为 RuleSet 配置、ID 和用户权限数据增加安全校验。
- 移除房间创建权限检查中会写入不存在 `doc/etc` 目录的临时调试代码。
- 增加双语变更日志。

## 根因

已有时光重现房间时，房间列表模板会将全局 `$ruleset_config` 覆盖为单条 RuleSet 配置。同一请求后续再次遍历完整列表时，会将 `name`、`credits_cost` 等标量字段误当作 RuleSet 条目，导致字符串/整数数组偏移警告和损坏的创建界面。

## 影响

时光重现房间列表和创建权限检查恢复正常；非法配置 ID 或异常输入会安全拒绝，不再向玩家输出调试文件写入错误。

## 验证

使用 `C:\Soft\php-7.4.33-nts-Win32-vc15-x64\php.exe`：
- 对受影响 PHP 文件执行语法检查；
- 回归验证旧模板覆盖 `$ruleset_config` 后，7 个 RuleSet 仍完整可用；
- 验证管理员/普通用户权限、非法输入拒绝，以及权限检查不再生成调试文件。