### PR TITLE
Fix Laika blessing choices

### DIFF
--- a/doc/20260811-032201-fix-laika-blessing-options.txt
+++ b/doc/20260811-032201-fix-laika-blessing-options.txt
@@ -1,0 +1,18 @@
+莱卡祝福选择页修复 / Laika Blessing Choice Page Fix
+====================================================
+
+中文
+----
+
+1. 修复莱卡模式配置的作用域：规则集行为文件由函数内加载时，`laika_1.php` 中的 `$laika_mode_config` 曾只存在于该函数的局部作用域；事件逻辑随后从全局作用域读取配置，祝福池因此为空。
+2. 现在配置文件显式绑定全局变量。祝福触发时会生成并持久化三项候选，动态对话分支也会得到对应按钮，不再出现只有“请选择：”的空选择页；已受影响的空候选事件会在下次处理时自动重建。
+3. 将 `dialogue.js` 改为在两套游戏页面头部加载，而非随 AJAX 注入的对话 HTML 加载。这样翻页与选择提交函数在动态打开的对话中也始终可用。
+4. 扩展莱卡回归测试：以与实际加载器相同的函数作用域加载规则集，并验证祝福配置、候选生成和动态分支渲染。
+
+English
+-------
+
+1. Fixed the Laika configuration scope. When the RuleSet behavior file was included from a loader function, `$laika_mode_config` was local to that function while event hooks later read a global variable, leaving the blessing pool empty.
+2. The configuration now explicitly binds the global variable. Blessing triggers persist three offers and populate the matching dynamic dialogue buttons instead of rendering an empty choice page; already-persisted empty offer lists are rebuilt when processed.
+3. Moved `dialogue.js` to each game page header rather than an AJAX-inserted dialogue fragment, so page navigation and choice submission are always available.
+4. Extended the Laika regression test to load the RuleSet in the same function scope as production and to verify blessing configuration, offer creation, and dynamic choice rendering.

--- a/gamedata/ruleset/LAIKAADVENT/include/ruleset.func.php
+++ b/gamedata/ruleset/LAIKAADVENT/include/ruleset.func.php
@@ -18,8 +18,11 @@ function laika_get_config($section = '')
 {
     global $laika_mode_config;
 
-    if ($section !== '' && isset($laika_mode_config[$section])) {
-        return $laika_mode_config[$section];
+    if (empty($laika_mode_config) || !is_array($laika_mode_config)) return Array();
+    if ($section !== '') {
+        return isset($laika_mode_config[$section]) && is_array($laika_mode_config[$section])
+            ? $laika_mode_config[$section]
+            : Array();
     }
     return $laika_mode_config;
 }
@@ -83,10 +86,9 @@ function laika_init_state(&$data)
     if (empty($state['thresholds']) || !is_array($state['thresholds'])) $state['thresholds'] = Array();
     if (empty($state['tax_conditions']) || !is_array($state['tax_conditions'])) $state['tax_conditions'] = Array();
     if (!isset($state['next_blessing'])) {
-        $state['next_blessing'] = rand(
-            intval($cfg['first_offer_min_actions']),
-            intval($cfg['first_offer_max_actions'])
-        );
+        $min_actions = max(1, intval(isset($cfg['first_offer_min_actions']) ? $cfg['first_offer_min_actions'] : 1));
+        $max_actions = max($min_actions, intval(isset($cfg['first_offer_max_actions']) ? $cfg['first_offer_max_actions'] : $min_actions));
+        $state['next_blessing'] = rand($min_actions, $max_actions);
     }
     if (empty($state['progress_snapshot']) || !is_array($state['progress_snapshot'])) {
         $state['progress_snapshot'] = laika_collect_progress_snapshot($data);
@@ -146,6 +148,65 @@ function laika_clear_dialogue(&$data)
     unset($data['clbpara']['noskip_dialogue']);
 }
 
+// 生成本次祝福的候选项；配置错误时返回空数组而不创建不可操作的事件。
+// Build the offers for one blessing event; return an empty array on invalid configuration instead of creating an unusable event.
+function laika_generate_blessing_offers()
+{
+    $cfg = laika_get_config('blessing');
+    $pool = !empty($cfg['pool']) && is_array($cfg['pool']) ? $cfg['pool'] : Array();
+    $pool_keys = array_keys($pool);
+    shuffle($pool_keys);
+    $offer_count = min(max(0, intval(isset($cfg['offer_count']) ? $cfg['offer_count'] : 0)), count($pool_keys));
+    $offers = Array();
+
+    for ($i = 0; $i < $offer_count; $i++) {
+        $offer_id = $pool_keys[$i];
+        if (empty($pool[$offer_id]) || !is_array($pool[$offer_id])) continue;
+        $offer = $pool[$offer_id];
+        $offer['id'] = $offer_id;
+        $offers[] = $offer;
+    }
+    return $offers;
+}
+
+// 获取祝福持续回合；至少保留一回合，避免受损旧状态立即失效。
+// Get the blessing duration; keep at least one action so repaired legacy state cannot expire immediately.
+function laika_generate_blessing_duration()
+{
+    $cfg = laika_get_config('blessing');
+    $min_actions = max(1, intval(isset($cfg['duration_min_actions']) ? $cfg['duration_min_actions'] : 1));
+    $max_actions = max($min_actions, intval(isset($cfg['duration_max_actions']) ? $cfg['duration_max_actions'] : $min_actions));
+    return rand($min_actions, $max_actions);
+}
+
+// 修复旧版本留下的空祝福候选，避免玩家被卡在没有按钮的选择页。
+// Repair empty legacy blessing offers so a player cannot be trapped on a choice page without buttons.
+function laika_restore_pending_blessing(&$data)
+{
+    global $log;
+
+    if (empty($data['clbpara']['laika']['pending']['type'])
+        || $data['clbpara']['laika']['pending']['type'] != 'blessing') return false;
+
+    $pending = &$data['clbpara']['laika']['pending'];
+    if (empty($pending['offers']) || !is_array($pending['offers'])) {
+        $pending['offers'] = laika_generate_blessing_offers();
+        if (empty($pending['offers'])) {
+            unset($data['clbpara']['laika']['pending']);
+            if (!empty($data['clbpara']['dialogue']) && $data['clbpara']['dialogue'] == 'laika_blessing') {
+                laika_clear_dialogue($data);
+            }
+            $log .= '<span class="red">莱卡的祝福配置无效，本次选择已取消。</span><br>';
+            return false;
+        }
+        $log .= '<span class="yellow">莱卡重新整理了本次祝福选项。</span><br>';
+    }
+    if (empty($pending['duration']) || intval($pending['duration']) < 1) {
+        $pending['duration'] = laika_generate_blessing_duration();
+    }
+    return true;
+}
+
 function laika_install_dynamic_dialogue(&$data)
 {
     global $dialogues, $dialogue_branch, $dialogue_log;
@@ -165,7 +226,8 @@ function laika_install_dynamic_dialogue(&$data)
         $dialogue_log['laika_tax'] = '';
     }
 
-    if (!empty($state['pending']['type']) && $state['pending']['type'] == 'blessing') {
+    if (!empty($state['pending']['type']) && $state['pending']['type'] == 'blessing'
+        && laika_restore_pending_blessing($data)) {
         $pending = $state['pending'];
         $dialogues['laika_blessing'] = Array(
             '<span class="lime b">“哇呼～”</span><br><br>只有这一声感叹还残留着少女般的轻盈。紧接着，三道彼此矛盾的星光落到你面前。',
@@ -1074,19 +1136,17 @@ function laika_maybe_offer_blessing(&$data)
 
     $state = &$data['clbpara']['laika'];
     if (!empty($state['blessing']) || intval($state['actions']) < intval($state['next_blessing'])) return false;
-    $cfg = laika_get_config('blessing');
-    $pool_keys = array_keys($cfg['pool']);
-    shuffle($pool_keys);
-    $offer_count = min(intval($cfg['offer_count']), count($pool_keys));
-    $duration = rand(intval($cfg['duration_min_actions']), intval($cfg['duration_max_actions']));
-    $offers = Array();
-    for ($i = 0; $i < $offer_count; $i++) {
-        $offer = $cfg['pool'][$pool_keys[$i]];
-        $offer['id'] = $pool_keys[$i];
-        $offers[] = $offer;
+    $offers = laika_generate_blessing_offers();
+    if (empty($offers)) {
+        $log .= '<span class="red">莱卡的祝福配置无效，未生成选择事件。</span><br>';
+        return false;
     }
+    $duration = laika_generate_blessing_duration();
+    $cfg = laika_get_config('blessing');
+    $min_actions = max(1, intval(isset($cfg['offer_min_actions']) ? $cfg['offer_min_actions'] : 1));
+    $max_actions = max($min_actions, intval(isset($cfg['offer_max_actions']) ? $cfg['offer_max_actions'] : $min_actions));
     $state['pending'] = Array('type' => 'blessing', 'offers' => $offers, 'duration' => $duration);
-    $state['next_blessing'] = intval($state['actions']) + rand(intval($cfg['offer_min_actions']), intval($cfg['offer_max_actions']));
+    $state['next_blessing'] = intval($state['actions']) + rand($min_actions, $max_actions);
     laika_set_dialogue($data, 'laika_blessing', true);
     $log .= '<span class="lime b">“哇呼～请选择一个祝福吧。”</span><br>';
     laika_install_dynamic_dialogue($data);
@@ -1098,6 +1158,7 @@ function laika_resolve_blessing(&$data, $choice)
     global $log;
 
     if (empty($data['clbpara']['laika']['pending']['type']) || $data['clbpara']['laika']['pending']['type'] != 'blessing') return false;
+    if (!laika_restore_pending_blessing($data)) return false;
     $pending = $data['clbpara']['laika']['pending'];
     if (!isset($pending['offers'][$choice])) return false;
     $offer = $pending['offers'][$choice];

--- a/gamedata/ruleset/LAIKAADVENT/laika_1.php
+++ b/gamedata/ruleset/LAIKAADVENT/laika_1.php
@@ -11,6 +11,9 @@ if (!defined('IN_GAME')) {
  * 测试时优先调整本文件；核心事件逻辑位于 include/ruleset.func.php。
  * Tune this file first during playtests. Event logic lives in include/ruleset.func.php.
  */
+// RuleSet 加载器会在函数作用域内载入本文件；显式写入全局配置供事件函数读取。
+// The RuleSet loader includes this file from a function scope, so publish the configuration globally for event hooks.
+global $laika_mode_config;
 $laika_mode_config = Array(
     'version' => 1,
 

--- a/gamedata/ruleset/LAIKAADVENT/tests/laika_ruleset_test.php
+++ b/gamedata/ruleset/LAIKAADVENT/tests/laika_ruleset_test.php
@@ -106,7 +106,14 @@ function laika_test_empty_slots()
 }
 
 $log = '';
-require_once GAME_ROOT.'gamedata/ruleset/LAIKAADVENT/include/ruleset.func.php';
+// 模拟 RuleSet 加载器在函数内部载入行为文件，以覆盖配置作用域。
+// Mirror the RuleSet loader's function-scoped include so configuration scope is covered by this test.
+function laika_test_load_ruleset_functions()
+{
+    require_once GAME_ROOT.'gamedata/ruleset/LAIKAADVENT/include/ruleset.func.php';
+}
+
+laika_test_load_ruleset_functions();
 
 $request_lock_result = ruleset_command_request_begin_hook();
 laika_test_assert($request_lock_result && laika_command_lock_is_held(), '莱卡请求在读取玩家行前取得共享进度锁');
@@ -124,6 +131,8 @@ laika_test_assert($request_lock_pos !== false && $player_read_pos !== false
     '莱卡共享进度锁覆盖玩家读取、团队进度改写和最终保存');
 
 $config = laika_get_config();
+laika_test_assert(!empty($config['blessing']['pool']) && intval($config['blessing']['offer_count']) === 3,
+    '函数作用域加载后祝福配置仍可被全局事件逻辑读取');
 laika_test_assert(isset($config['cog']['trigger_items']['破灭之诗']), '旧解离触发物已配置');
 laika_test_assert($config['tax']['ordinary_npc_threshold'] === 5, '普通NPC税阈值集中可配置');
 
@@ -169,6 +178,36 @@ laika_test_assert($blessing_player['att'] === 200 && $blessing_player['def'] ===
 laika_tick_blessing($blessing_player);
 laika_tick_blessing($blessing_player);
 laika_test_assert($blessing_player['att'] === 100 && $blessing_player['def'] === 100, '悖论祝福到期后精确撤销数值变化');
+
+$dialogues = Array();
+$dialogue_branch = Array();
+$dialogue_log = Array();
+$blessing_offer_player = laika_test_player();
+laika_init_state($blessing_offer_player);
+$blessing_offer_player['clbpara']['laika']['next_blessing'] = 0;
+laika_maybe_offer_blessing($blessing_offer_player);
+$expected_offer_count = min(intval($config['blessing']['offer_count']), count($config['blessing']['pool']));
+laika_test_assert(count($blessing_offer_player['clbpara']['laika']['pending']['offers']) === $expected_offer_count,
+    '祝福事件会持久化完整的可选祝福列表');
+laika_test_assert(isset($dialogue_branch['laika_blessing'])
+    && count($dialogue_branch['laika_blessing']) === $expected_offer_count
+    && !empty($dialogue_branch['laika_blessing'][0]),
+    '祝福选择页会渲染每个可选祝福');
+
+$repaired_blessing_player = laika_test_player();
+laika_init_state($repaired_blessing_player);
+$repaired_blessing_player['clbpara']['laika']['pending'] = Array(
+    'type' => 'blessing',
+    'offers' => Array(),
+    'duration' => 0,
+);
+laika_install_dynamic_dialogue($repaired_blessing_player);
+laika_test_assert(count($repaired_blessing_player['clbpara']['laika']['pending']['offers']) === $expected_offer_count
+    && intval($repaired_blessing_player['clbpara']['laika']['pending']['duration']) > 0,
+    '历史空祝福事件会被修复为可选择的候选列表');
+laika_test_assert(count($dialogue_branch['laika_blessing']) === $expected_offer_count
+    && !empty($dialogue_branch['laika_blessing'][0]),
+    '修复后的历史祝福事件会渲染可点击选项');
 
 $item_player = laika_test_player();
 laika_init_state($item_player);

--- a/templates/default/dialogue.htm
+++ b/templates/default/dialogue.htm
@@ -1,5 +1,4 @@
 <dialog id="dialogue" style="width: 460px; max-width: 90%;max-height: 80%;">
-<script src="include/dialogue.js?v=<!--{eval time();}-->"></script>
 <p><center>
 
 <!-- 当前阅读页面 -->

--- a/templates/default/header.htm
+++ b/templates/default/header.htm
@@ -24,6 +24,7 @@ jQuery.noConflict();
 <script type="text/javascript" src="include/json.js"></script>
 <script type="text/javascript" src="include/pako.js"></script>
 <!--{if (CURSCRIPT == 'game')}-->
+<script type="text/javascript" src="include/dialogue.js?v=<!--{eval time();}-->"></script>
 <script type="text/javascript" src="include/record.js"></script>
 <!--{/if}-->
 <!--{loop $plsinfo $places $info}-->

--- a/templates/nouveau/header.htm
+++ b/templates/nouveau/header.htm
@@ -23,6 +23,7 @@
 <script type="text/javascript" src="include/json.js"></script>
 <script type="text/javascript" src="include/pako.js"></script>
 <!--{if (CURSCRIPT == 'game')}-->
+<script type="text/javascript" src="include/dialogue.js?v=<!--{eval time();}-->"></script>
 <script type="text/javascript" src="include/record.js"></script>
 <!--{/if}-->
 <script type="text/javascript" src="templates/nouveau/assets/js/window-manager.js" defer></script>


### PR DESCRIPTION
## Summary

- Fix Laika configuration loading so blessing offers are available when RuleSet hooks run.
- Rebuild empty persisted blessing offers and load dialogue controls with the initial game page.
- Add regression coverage for function-scoped loading and blessing choice rendering.

## Root cause

The RuleSet loader included `laika_1.php` through a function-scoped include, leaving `$laika_mode_config` local while the hooks read it as a global. This produced a blessing event with no offers, so the UI displayed an empty choice page.

## Player impact

Players now receive three selectable blessing options. Existing empty blessing events self-repair on the next request, and dynamically opened dialogs retain functioning page/choice controls.

## Validation

- `git diff --check`
- `node --check include/dialogue.js`
- Dialogue page/choice-handler Node smoke test
- PHP lint/regression script was not run locally because PHP is not installed in this terminal environment.